### PR TITLE
Code cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Source resides in `src/main/kotlin/com/hightouchinc`, with command-line entrypoints in `WireguardManagerCommand.kt` and supporting models and templating services nearby. Configuration files live in `src/main/resources`, including Flyway migrations under `db` and JTE templates under `template`. Tests are in `src/test/groovy`, organised as Spock specifications mirroring the main package layout. Gradle build logic is defined in `build.gradle` and `gradle.properties`.
+
+## Build, Test, and Development Commands
+- `./gradlew build` compiles the CLI, runs unit tests, and produces the staged artifacts in `build/`.
+- `./gradlew test` runs the Spock specification suite only; use when iterating.
+- `./gradlew shadowJar` assembles a runnable fat jar at `build/libs/wireguard-manager-all.jar` for manual installs.
+- `./gradlew run --args="--help"` executes the CLI locally without assembling a jar, useful for smoke-checking argument wiring.
+
+## Runtime & Configuration Tips
+Defaults in `application.properties` target production paths: the H2 database and rendered configs go under `/etc/wireguard`. For local development, export `WIREGUARD_ROOT=$(pwd)/build/dev-wireguard` (or similar) before running commands so state stays in the workspace. Verify that directory exists or Gradle tasks will create it on demand.
+
+## Coding Style & Naming Conventions
+Kotlin code uses the Kotlin-official profile with three-space indentation, a 120-character line limit, and trailing commas enabled in multiline literals (see `.editorconfig`). Avoid star imports—leave IntelliJ on the repo defaults—and prefer expression bodies only when they stay within the line limit. Keep DTOs as data classes, keep service classes focused, and name JTE templates with snake_case filenames that mirror the rendered resource. CLI command names stay kebab-case to match Picocli options.
+
+## Testing Guidelines
+Spock specs live alongside the code they verify; name them `*Spec.groovy` and mirror the package path. Each new command branch or templating rule should have at least one specification covering success and validation failures. Run `./gradlew test` prior to opening a PR; CI expects a clean `build` run. If adding integration-level behaviour, stub external processes via ZT-Exec to avoid system calls.
+
+## Commit & Pull Request Guidelines
+Commit messages follow short, imperative summaries (`Add peer templating fallback`), optionally followed by detail in the body. Group related Kotlin and resource changes together so reviewers can trace template updates. Pull requests should link relevant issues, describe runtime impacts, and include before/after snippets for rendered configs when templates change. Confirm the chosen `WIREGUARD_ROOT` path used during testing in the PR description to help reviewers reproduce results.
+
+## Do
+- use Micronaut version specified in `gradle.properties`
+- prefer library solutions over writing custom code
+- use Micronaut to the fullest
+
+## Safety and permissions
+Allowed without prompt:
+- read files, list files
+- ./gradlew test
+- ./gradlew tasks
+
+Ask first:
+- git commit
+- git push
+- deleting files

--- a/src/main/kotlin/com/hightouchinc/WireguardManagerCommand.kt
+++ b/src/main/kotlin/com/hightouchinc/WireguardManagerCommand.kt
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory
 import picocli.CommandLine
 
 @CommandLine.Command(
-   version = ["0.0.2"],
+   version = ["0.0.3"],
    name = "wireguard-manager",
    description = ["CLI tool to manage a wireguard server and generate client configurations"],
    mixinStandardHelpOptions = true,
@@ -45,13 +45,17 @@ class WireguardManagerCommand : Callable<Int>, CommandLine.IExitCodeGenerator {
       fun main(args: Array<String>) {
          val logger = LoggerFactory.getLogger(WireguardManagerCommand::class.java)
 
-         try {
+         val exitCode = try {
             val result: Int? = PicocliRunner.call(WireguardManagerCommand::class.java, *args)
 
-            exitProcess(result ?: 0) // FIXME: status is not being returned from commands, need to figure out why
+            result ?: 0 // FIXME: status is not being returned from commands, need to figure out why
          } catch (e: Throwable) {
             logger.error("Unexpected error while running Wireguard manager", e)
+
+            1
          }
+
+         exitProcess(exitCode)
       }
    }
 }

--- a/src/main/kotlin/com/hightouchinc/command/render/RenderServerConfigurationCommand.kt
+++ b/src/main/kotlin/com/hightouchinc/command/render/RenderServerConfigurationCommand.kt
@@ -8,8 +8,9 @@ import com.hightouchinc.persistence.server.ServerRepository
 import com.hightouchinc.templating.TemplatingService
 import io.micronaut.context.annotation.Value
 import jakarta.inject.Inject
-import java.io.File
 import java.io.FileWriter
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.concurrent.Callable
 import org.jline.consoleui.prompt.ConsolePrompt
 import org.jline.terminal.TerminalBuilder
@@ -33,7 +34,10 @@ class RenderServerConfigurationCommand @Inject constructor(
    private fun renderServerConfig(server: Server) {
       val peers = peerRepository.findByServerId(server.id.value).map(PeerEntity::toModel)
 
-      FileWriter(File(wireGuardManagerRoot, "wg0.conf")).use { fw ->  // TODO: This needs to be configuration on the server table that is auto-incrementing or something
+      val outputDir = Path.of(wireGuardManagerRoot)
+      Files.createDirectories(outputDir)
+
+      FileWriter(outputDir.resolve("wg0.conf").toFile()).use { fw ->  // TODO: This needs to be configuration on the server table that is auto-incrementing or something
          templatingService.renderServerConfig(server, peers, fw)
 
          fw.flush()

--- a/src/main/kotlin/com/hightouchinc/model/CompletionError.kt
+++ b/src/main/kotlin/com/hightouchinc/model/CompletionError.kt
@@ -5,6 +5,7 @@ import org.slf4j.Logger
 
 sealed class CompletionError {
    class FirstThreeOctetsTooShort(val input: String): CompletionError()
+   class FirstThreeOctetsTooLong(val input: String): CompletionError()
    class FirstThreeOctetsNotFormattedCorrectly(val input: String): CompletionError()
    class PortTooLow(val input: Int): CompletionError()
    class PortTooHigh(val input: Int): CompletionError()
@@ -26,9 +27,11 @@ sealed class CompletionError {
       fun printError(logger: Logger, completionErrorIn: Outcome.Failure<CompletionError>) =
          when (val completionError = completionErrorIn.error) {
             is FirstThreeOctetsNotFormattedCorrectly ->
-               logger.error("First three octets is not correctly formatted correctly: {}", completionError.input)
+               logger.error("First three octets are not formatted correctly: {}", completionError.input)
             is FirstThreeOctetsTooShort ->
-               logger.error("first three octets is too short : {}", completionError.input)
+               logger.error("First three octets are too short: {}", completionError.input)
+            is FirstThreeOctetsTooLong ->
+               logger.error("First three octets are too long: {}", completionError.input)
             is PortNotNumber ->
                logger.error("Port was not a number: {}", completionError.input)
             is PortTooHigh ->
@@ -58,4 +61,3 @@ sealed class CompletionError {
          }
    }
 }
-

--- a/src/main/kotlin/com/hightouchinc/model/base/Inet.kt
+++ b/src/main/kotlin/com/hightouchinc/model/base/Inet.kt
@@ -13,7 +13,8 @@ value class FirstThreeOctets private constructor(val value: String) {
       @JvmStatic
       fun create(octets: String): Outcome<FirstThreeOctets, CompletionError> =
          when {
-            octets.length > 11 -> Outcome.Failure(CompletionError.FirstThreeOctetsTooShort(octets))
+            octets.length < 5 -> Outcome.Failure(CompletionError.FirstThreeOctetsTooShort(octets))
+            octets.length > 11 -> Outcome.Failure(CompletionError.FirstThreeOctetsTooLong(octets))
             !regex.matches(octets) -> Outcome.Failure(CompletionError.FirstThreeOctetsNotFormattedCorrectly(octets))
             else -> Outcome.Success(FirstThreeOctets(octets))
          }
@@ -52,8 +53,8 @@ value class FourthOctet private constructor(val value: Int) {
       @JvmStatic
       fun create(octet: Int): Outcome<FourthOctet, CompletionError> =
          when {
-            octet < 1 -> Outcome.Failure(CompletionError.PortTooLow(octet))
-            octet > 254 -> Outcome.Failure(CompletionError.PortTooHigh(octet))
+            octet < 1 -> Outcome.Failure(CompletionError.OctetTooLow(octet))
+            octet > 254 -> Outcome.Failure(CompletionError.OctetTooHigh(octet))
             else -> Outcome.Success(FourthOctet(octet))
          }
    }

--- a/src/main/kotlin/com/hightouchinc/persistence/peer/PeerEntity.kt
+++ b/src/main/kotlin/com/hightouchinc/persistence/peer/PeerEntity.kt
@@ -47,19 +47,19 @@ data class PeerEntity(
          name = Text.create(name),
          fourthOctet = when(val fourthOctet = FourthOctet.create(fourthOctet)) {
             is Outcome.Success -> fourthOctet.value
-            is Outcome.Failure -> throw IllegalStateException("Invalid fourth octet in database: $fourthOctet")
+            is Outcome.Failure -> throw IllegalStateException("Invalid fourth octet in database: ${fourthOctet.error}")
          },
          privateKey = when(val privateKey = PrivateWireGuardKey.create(privateKey)) {
             is Outcome.Success -> privateKey.value
-            is Outcome.Failure -> throw IllegalStateException("Invalid private key in database: $privateKey")
+            is Outcome.Failure -> throw IllegalStateException("Invalid private key in database: ${privateKey.error}")
          },
          publicKey = when(val publicKey = PublicWireGuardKey.create(publicKey)) {
             is Outcome.Success -> publicKey.value
-            is Outcome.Failure -> throw IllegalStateException("Invalid public key in database: $publicKey")
+            is Outcome.Failure -> throw IllegalStateException("Invalid public key in database: ${publicKey.error}")
          },
          presharedKey = when(val presharedKey = PresharedWireGuardKey.create(presharedKey)) {
             is Outcome.Success -> presharedKey.value
-            is Outcome.Failure -> throw IllegalStateException("Invalid preshared key in database: $presharedKey")
+            is Outcome.Failure -> throw IllegalStateException("Invalid preshared key in database: ${presharedKey.error}")
          },
          clientConfig = Text.create(peerConfig),
          server = server.toModel()

--- a/src/main/kotlin/com/hightouchinc/templating/TemplatingService.kt
+++ b/src/main/kotlin/com/hightouchinc/templating/TemplatingService.kt
@@ -11,17 +11,16 @@ import java.io.Writer
 
 @Singleton
 class TemplatingService {
+   private val codeResolver = ResourceCodeResolver("template")
+   private val jteEngine = TemplateEngine.create(codeResolver, ContentType.Plain)
+
    fun renderServerConfig(server: Server, peers: List<Peer>, writer: Writer) {
-      val codeResolver = ResourceCodeResolver("template")
-      val jteEngine = TemplateEngine.create(codeResolver, ContentType.Plain)
       val templateOutput = WriterOutput(writer)
 
       jteEngine.render("wgX.conf.kte", ServerTemplateModel(server, peers), templateOutput)
    }
 
    fun renderClientConfig(peer: Peer, writer: Writer) {
-      val codeResolver = ResourceCodeResolver("template")
-      val jteEngine = TemplateEngine.create(codeResolver, ContentType.Plain)
       val templateOutput = WriterOutput(writer)
 
       jteEngine.render(


### PR DESCRIPTION
src/main/kotlin/com/hightouchinc/command/render/RenderServerConfigurationCommand.kt:38: create the output directory before writing wg0.conf to prevent render failures when the target folder is missing.

AGENTS.md:17: update Kotlin style guidance to match .editorconfig (three-space indent, 120-column limit, trailing commas, no star imports).

src/main/kotlin/com/hightouchinc/model/base/Inet.kt:16: refine first-three-octet validation with explicit too-short/too-long checks.

src/main/kotlin/com/hightouchinc/model/CompletionError.kt:6: add FirstThreeOctetsTooLong and polish log wording for octet errors.

src/main/kotlin/com/hightouchinc/WireguardManagerCommand.kt:40: ensure main exits with a non-zero status on unexpected errors even with the try-expression rewrite.

src/main/kotlin/com/hightouchinc/persistence/peer/PeerEntity.kt:39: include underlying CompletionError details in thrown IllegalStateExceptions to improve diagnostics.

src/main/kotlin/com/hightouchinc/command/render/RenderPeerConfigurationCommand.kt:15: fix command description and short-circuit when no servers exist so exit codes stay accurate